### PR TITLE
style: enhance code block appearance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ kramdown:
   input: GFM
   math_engine: mathjax
   hard_wrap: false
+  syntax_highlighter_opts:
+    line_numbers: true
 
 highlighter: rouge
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,6 +152,44 @@ pre {
   border: 1px solid var(--glass-border);
 }
 
+/* 多行代码块样式 */
+.highlighter-rouge {
+  position: relative;
+  background: var(--code-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.highlighter-rouge pre {
+  margin: 0;
+  border: none;
+}
+.highlighter-rouge code::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 6px;
+  right: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.highlighter-rouge .rouge-table {
+  width: 100%;
+  border-spacing: 0;
+}
+.highlighter-rouge .rouge-table td {
+  padding: 0;
+}
+.highlighter-rouge .gutter {
+  user-select: none;
+  text-align: right;
+  padding: 0 12px;
+  border-right: 1px solid var(--glass-border);
+  color: var(--muted);
+}
+.highlighter-rouge .code {
+  padding-left: 12px;
+}
+
 blockquote {
   margin: 0;
   padding: 10px 14px;


### PR DESCRIPTION
## Summary
- show line numbers for code blocks
- style multi-line code blocks with background, border, and language label

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689ef47962d883339d4e96caa190d9a8