### PR TITLE
style: enhance code block appearance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@ kramdown:
   input: GFM
   math_engine: mathjax
   hard_wrap: false
+  syntax_highlighter_opts:
+    block:
+      line_numbers: true
 
 highlighter: rouge
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,5 +33,6 @@
         <p>© {{ site.time | date: "%Y" }} lzray的博客 · 由 Jekyll & GitHub Pages 驱动</p>
       </div>
     </footer>
+    <script src="{{ '/assets/js/code-lang.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -140,16 +140,63 @@ ul.post-list li:hover {
 a { color: var(--link); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
-pre, code {
-  background: var(--code-bg);
-  border-radius: 12px;
+code {
   font-family: "JetBrains Mono", "DengXian", monospace;
 }
-code { padding: 2px 6px; }
 pre {
+  background: var(--code-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  font-family: "JetBrains Mono", "DengXian", monospace;
   padding: 14px;
   overflow: auto;
+}
+
+/* 多行代码块样式 */
+.highlighter-rouge,
+.highlight {
+  position: relative;
+  background: var(--code-bg);
   border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.highlighter-rouge pre,
+.highlight pre {
+  margin: 0;
+  background: transparent;
+  border: none;
+  padding: 14px;
+}
+.highlighter-rouge::before,
+.highlight::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 6px;
+  right: 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.highlighter-rouge .rouge-table,
+.highlight .rouge-table {
+  width: 100%;
+  border-spacing: 0;
+}
+.highlighter-rouge .rouge-table td,
+.highlight .rouge-table td {
+  padding: 0;
+}
+.highlighter-rouge .gutter,
+.highlight .gutter {
+  user-select: none;
+  text-align: right;
+  padding: 0 12px;
+  border-right: 1px solid var(--glass-border);
+  color: var(--muted);
+}
+.highlighter-rouge .code,
+.highlight .code {
+  padding-left: 12px;
 }
 
 blockquote {

--- a/assets/js/code-lang.js
+++ b/assets/js/code-lang.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.highlighter-rouge, .highlight').forEach(block => {
+    let langClass = Array.from(block.classList).find(cls => cls.startsWith('language-'));
+    if (!langClass) {
+      const code = block.querySelector('code');
+      if (code) {
+        langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
+      }
+    }
+    if (langClass) {
+      block.dataset.lang = langClass.replace('language-', '');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- show line numbers for code blocks
- add borders and language labels to multi-line code blocks
- prevent inline code from losing text and ensure block backgrounds render

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689ef47962d883339d4e96caa190d9a8