### PR TITLE
Add sidebar TOC and light blue code blocks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,5 +34,6 @@
       </div>
     </footer>
     <script src="{{ '/assets/js/code-lang.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/toc.js' | relative_url }}"></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,14 +1,20 @@
 ---
 layout: default
 ---
-<article class="post">
-  <h1 class="post-title">{{ page.title }}</h1>
-  <div class="post-meta">
-    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%Y-%m-%d" }}</time>
-    {% if page.categories %} · {{ page.categories | join: ", " }}{% endif %}
-    {% if page.tags %} · {{ page.tags | join: ", " }}{% endif %}
-  </div>
-  <div class="post-content">
-    {{ content }}
-  </div>
-</article>
+<div class="post-wrapper">
+  <aside id="outline-panel"></aside>
+  <article id="post-content" class="post">
+    <h1 class="post-title">{{ page.title }}</h1>
+    <div class="post-meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%Y-%m-%d" }}</time>
+      {% if page.categories %} · {{ page.categories | join: ", " }}{% endif %}
+      {% if page.tags %} · {{ page.tags | join: ", " }}{% endif %}
+    </div>
+    <div class="post-content">
+      {{ content }}
+    </div>
+  </article>
+</div>
+<div id="container-floating">
+  <div id="floating-button"><p class="more">&gt;</p></div>
+</div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,7 +10,7 @@
   --text: #111;
   --muted: #555;
   --link: #0a66c2;
-  --code-bg: rgba(255, 255, 255, 0.22);
+  --code-bg: rgba(173, 216, 230, 0.35);
   --shadow: 0 10px 30px rgba(0,0,0,0.15);
 }
 
@@ -21,7 +21,7 @@
     --text: #f2f2f2;
     --muted: #b7bcc3;
     --link: #6ab7ff;
-    --code-bg: rgba(255, 255, 255, 0.06);
+    --code-bg: rgba(173, 216, 230, 0.15);
     --shadow: 0 14px 34px rgba(0,0,0,0.35);
   }
 }
@@ -244,4 +244,66 @@ td, th {
   .site-nav a {
     margin-left: 0;
   }
+}
+
+/* --- Post layout with outline panel --- */
+.post-wrapper {
+  display: flex;
+  gap: 24px;
+}
+
+#outline-panel {
+  flex: 0 0 240px;
+  max-height: calc(100vh - 8rem);
+  overflow-y: auto;
+  position: sticky;
+  top: 6rem;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  padding: 14px;
+}
+
+#outline-panel ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+#outline-panel a {
+  color: var(--text);
+  text-decoration: none;
+  display: block;
+  padding: 4px 0;
+}
+
+#container-floating {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+}
+
+#floating-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #00897B;
+  border-radius: 50%;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#floating-button .more {
+  color: #f5f5f5;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.hidden { display: none !important; }
+
+@media (max-width: 768px) {
+  .post-wrapper { display: block; }
+  #outline-panel, #container-floating { display: none; }
 }

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const outline = document.getElementById('outline-panel');
+  const content = document.getElementById('post-content');
+  const btn = document.getElementById('floating-button');
+  if (!outline || !content || !btn) return;
+
+  const headings = content.querySelectorAll('h1, h2, h3');
+  if (headings.length === 0) {
+    outline.classList.add('hidden');
+    btn.classList.add('hidden');
+    return;
+  }
+
+  const ul = document.createElement('ul');
+  headings.forEach(h => {
+    if (!h.id) {
+      h.id = h.textContent.trim().toLowerCase().replace(/\s+/g, '-');
+    }
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.textContent = h.textContent;
+    a.href = '#' + h.id;
+    li.appendChild(a);
+    ul.appendChild(li);
+  });
+  outline.appendChild(ul);
+
+  btn.addEventListener('click', function () {
+    outline.classList.toggle('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- add flex-based post layout with toggleable outline panel
- generate table of contents with new script and rounded floating button
- use translucent light-blue background for code blocks

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689efb22402083338857c5eb58dc1511