### PR TITLE
feat: enhance code block display

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
     <link href="https://fonts.cdnfonts.com/css/avenir" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css" integrity="sha512-sG1gnP9Wcv16O3MHuvb6jVWeItPxX2VINeodIZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfbQ3VIAtF7RBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
     {% include mathjax.html %}
   </head>
   <body>
@@ -35,6 +36,7 @@
       </div>
     </footer>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js" integrity="sha512-XdFeoJEB6Digw1VE3DybMT0SqnX+ANXoy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdFMn/hTyBC0bY4Z1g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha512-G2gMerOEx+kt1/3uzMdGII4XESyqCCpt5TR1+t0NenE2no0RvrRZtGJPD7WvyaManIeZDVAD6QdlqzTeWY5Aew==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="{{ '/assets/js/code-lang.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/toc.js' | relative_url }}"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,7 +152,7 @@ pre {
   border-radius: 12px;
   font-family: "JetBrains Mono", "DengXian", monospace;
   padding: 14px;
-  overflow: auto;
+  overflow-x: auto;
   max-width: 100%;
 }
 

--- a/assets/js/code-lang.js
+++ b/assets/js/code-lang.js
@@ -2,7 +2,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('pre > code').forEach(code => {
     const langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
     if (langClass && code.parentElement) {
-      code.parentElement.dataset.lang = langClass.replace('language-', '');
+      const pre = code.parentElement;
+      pre.dataset.lang = langClass.replace('language-', '');
+      pre.classList.add(langClass, 'line-numbers');
     }
   });
 });


### PR DESCRIPTION
## Summary
- add Prism line numbers plugin and assets
- ensure `<pre>` blocks carry language classes and line numbers
- restrict code block overflow horizontally

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689f03cd64e883338cb3a92a3fc49b31