### PR TITLE
fix: enable code line numbers and highlighting

### DIFF
--- a/assets/js/code-lang.js
+++ b/assets/js/code-lang.js
@@ -1,10 +1,14 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('pre > code').forEach(code => {
-    const langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
-    if (langClass && code.parentElement) {
-      const pre = code.parentElement;
-      pre.dataset.lang = langClass.replace('language-', '');
-      pre.classList.add(langClass, 'line-numbers');
-    }
-  });
+// Ensure line numbers and language labels are applied before Prism runs
+document.querySelectorAll('pre > code').forEach(code => {
+  const langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
+  if (langClass && code.parentElement) {
+    const pre = code.parentElement;
+    pre.dataset.lang = langClass.replace('language-', '');
+    pre.classList.add(langClass, 'line-numbers');
+  }
 });
+
+// Trigger Prism after classes are set so highlighting and line numbers render correctly
+if (window.Prism && typeof window.Prism.highlightAll === 'function') {
+  window.Prism.highlightAll();
+}


### PR DESCRIPTION
## Summary
- ensure large code blocks display language label and line numbers before Prism runs
- trigger Prism highlighting after applying classes

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689f064b6e048333a2a9d15f6d949b9e