### PR TITLE
Fix code block layout and enable Prism highlighting

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -52,6 +52,15 @@ body {
   overflow-wrap: break-word;
 }
 
+/* allow header, footer and main content to stretch full width */
+.site-header .container,
+main.container.content,
+.site-footer .container {
+  max-width: none;
+  margin: 0;
+  border-radius: 0;
+}
+
 .glass {
   backdrop-filter: blur(14px) saturate(150%);
   -webkit-backdrop-filter: blur(14px) saturate(150%);
@@ -148,12 +157,12 @@ code {
 pre {
   position: relative;
   background: var(--code-bg);
-  border: 1px solid var(--glass-border);
-  border-radius: 12px;
   font-family: "JetBrains Mono", "DengXian", monospace;
   padding: 14px;
-  overflow-x: auto;
-  max-width: 100%;
+  overflow: auto;
+  width: 100%;
+  border: none;
+  border-radius: 0;
 }
 
 pre[data-lang]::before {
@@ -162,6 +171,11 @@ pre[data-lang]::before {
   top: 6px;
   right: 10px;
   font-size: 12px;
+  color: var(--muted);
+}
+
+/* ensure Prism line numbers are visible */
+pre.line-numbers .line-numbers-rows span:before {
   color: var(--muted);
 }
 

--- a/assets/js/code-lang.js
+++ b/assets/js/code-lang.js
@@ -1,14 +1,16 @@
 // Ensure line numbers and language labels are applied before Prism runs
-document.querySelectorAll('pre > code').forEach(code => {
-  const langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
-  if (langClass && code.parentElement) {
-    const pre = code.parentElement;
-    pre.dataset.lang = langClass.replace('language-', '');
-    pre.classList.add(langClass, 'line-numbers');
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre > code').forEach(code => {
+    const langClass = Array.from(code.classList).find(cls => cls.startsWith('language-'));
+    if (langClass && code.parentElement) {
+      const pre = code.parentElement;
+      pre.dataset.lang = langClass.replace('language-', '');
+      pre.classList.add(langClass, 'line-numbers');
+    }
+  });
+
+  // Trigger Prism after classes are set so highlighting and line numbers render correctly
+  if (window.Prism && typeof window.Prism.highlightAll === 'function') {
+    window.Prism.highlightAll();
   }
 });
-
-// Trigger Prism after classes are set so highlighting and line numbers render correctly
-if (window.Prism && typeof window.Prism.highlightAll === 'function') {
-  window.Prism.highlightAll();
-}


### PR DESCRIPTION
## Summary
- allow header, footer, and content containers to span full width
- improve `pre` styling and show Prism line numbers
- delay Prism initialization until DOM ready

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689f0983cf708333ba7a1b7dcfcc4ebe