### PR TITLE
fix: enable background music playback

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,6 +111,8 @@
       </div>
     </footer>
 
+    <audio id="site-bgm" src="{{ '/assets/audio/bgm.mp3' | relative_url }}" preload="auto" loop></audio>
+    <script src="{{ '/assets/js/bgm.js' | relative_url }}"></script>
 
 <script src="{{ \'/assets/js/code-lang.js\' | relative_url }}"></script>
     <script src="{{ '/assets/js/toc.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- restore original `bgm.mp3`
- add audio tag and load `bgm.js` so background music plays automatically

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe6f91b248333958e01e360d78c99